### PR TITLE
Fix broken W3C Web Storage API link

### DIFF
--- a/web-storage/index.html
+++ b/web-storage/index.html
@@ -15,7 +15,7 @@
   <div class="wrapper">
     <h1>Web storage</h1>
 
-    <p>This example is designed to demonstrate usage of the <a href="http://dev.w3.org/html5/webstorage/">W3C Web Storage API</a>. It should work as far back as IE8. Choose custom background colours, logos and fonts from the below drop down menus, then try closing and reopening the page — you will find that your choices are remembered, as they are stored using Web Storage. You can also visit the <a href="event.html" target="_blank">storage event output</a> (opens in new tab). Open this, change some values in the index page, then look at the events page — you'll see the storage changes reported.</p>
+    <p>This example is designed to demonstrate usage of the <a href="https://html.spec.whatwg.org/multipage/webstorage.html#webstorage">W3C Web Storage API</a>. It should work as far back as IE8. Choose custom background colours, logos and fonts from the below drop down menus, then try closing and reopening the page — you will find that your choices are remembered, as they are stored using Web Storage. You can also visit the <a href="event.html" target="_blank">storage event output</a> (opens in new tab). Open this, change some values in the index page, then look at the events page — you'll see the storage changes reported.</p>
 
     <form>
       <div>


### PR DESCRIPTION
Replaced:
http://dev.w3.org/html5/webstorage/

With:
https://html.spec.whatwg.org/multipage/webstorage.html#storage